### PR TITLE
Implement line numbers in file analysis

### DIFF
--- a/iscn_exemples.csv
+++ b/iscn_exemples.csv
@@ -1,4 +1,4 @@
-Karyotype,Count
+Formule,Count
 "47,XX,+8[20]",1
 "47,XX,+8[20]",1
 "45,XX,-7[10]/46,XX[10]",1


### PR DESCRIPTION
## Summary
- show line number for each formula when analyzing uploaded files
- adjust table layout to include the new column
- expect a `Formule` column instead of `Karyotype` in uploaded files
- detect the `Formule` column case-insensitively so `formule`, `FORMULE`, etc. all work

## Testing
- `python -m py_compile app.py My_expert_karyo_functions.py`


------
https://chatgpt.com/codex/tasks/task_e_684abb33a27c832c8ddcf1c173de4c58