### PR TITLE
Add implicit anomaly detection

### DIFF
--- a/app.py
+++ b/app.py
@@ -199,7 +199,8 @@ with tab2:
                         match = "✅" if has_count and count_auto == count_manuel else "❌" if has_count else "N/A"
                     
                     result_row = {
-                        "Ligne": idx + 2,  # +2 pour inclure l'en-tête du fichier
+                        # Ne pas compter la ligne d'en-tête
+                        "Ligne": idx + 1,
                         "Formule": formule_fichier,
                         "Comptage automatique": count_auto if not error else "Erreur",
                         "Anomalies détectées": anomalies_detail  # Version texte pour l'export


### PR DESCRIPTION
## Summary
- detect implicit anomalies (derivative and gain/loss) with new function
- include reference anomaly in explanations
- treat dicentric chromosomes explicitly
- keep old scoring logic for gains and losses

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684acb50e5a0832cb039ed6a2a432edd